### PR TITLE
fix function name

### DIFF
--- a/src/convert.coffee
+++ b/src/convert.coffee
@@ -147,7 +147,7 @@ convert.edges_vertices_to_faces_vertices_edges = (fold) ->
   both `faces_vertices` and `faces_edges` property.
   ###
   convert.edges_vertices_to_vertices_edges_sorted fold
-  convert.vertices_edges_to_faces_vertices fold
+  convert.vertices_edges_to_faces_vertices_edges fold
 
 convert.vertices_vertices_to_vertices_edges = (fold) ->
   ###


### PR DESCRIPTION
line 150 in convert.coffee is attempting to call "vertices_edges_to_faces_vertices", I think it's meant to be "vertices_edges_to_faces_vertices_edges". I made the change locally inside the Javascript build file, it appears to be working.